### PR TITLE
antlr 4.13.2 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!/abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
 upload_channels:
   - sfe1ed40
+channels:
+  - https://staging.continuum.io/prefect/fs/maven-feedstock/pr5/7fe889f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - https://staging.continuum.io/prefect/fs/maven-feedstock/pr5/7fe889f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
 upload_channels:
   - sfe1ed40
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = "4.13.2" %}
+{% set version = "4.9.3" %}
 package:
   name: antlr
   version: {{ version }}
 
 source:
   url: https://github.com/antlr/antlr{{ version[0] }}/archive/{{ version }}.tar.gz
-  sha256: 9f18272a9b32b622835a3365f850dd1063d60f5045fb1e12ce475ae6e18a35bb
+  sha256: efe4057d75ab48145d4683100fec7f77d7f87fa258707330cadd1f8e6f7eecae
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,6 @@
-{% set patch_level = "-1" %}
 {% set version = "4.13.2" %}
-
-# sometimes part of the tag name (with the hyphen separator).
-# however, this has changed without warning (with a different sha256) in the past...
-# {% set patch_level = "-1" %}
-
 package:
   name: antlr
-  # this version drives maven options in build.sh/bld.bat
-  # version: {{ version }}{{ patch_level.replace("-", "_") }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [s390x]
 
 requirements:
   build:


### PR DESCRIPTION
antlr 4.13.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5665]
- dev_url:        https://github.com/antlr/antlr4
- conda_forge:
- pypi:           n/a
- pypi inspector: n/a
- Depends on:
    - https://github.com/AnacondaRecipes/maven-feedstock/pull/5
- Dependency for:
    - https://github.com/AnacondaRecipes/hydra-core-feedstock/pull/2
### Explanation of changes:


- skipping s390x due to `maven` dependency not being on `s390x`.
- building `4.9.2` despite `conda-forge` had `4.13.2` because we need this for https://github.com/AnacondaRecipes/hydra-core-feedstock/pull/2


[PKG-5665]: https://anaconda.atlassian.net/browse/PKG-5665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ